### PR TITLE
515178 Modified the UserControl sample in stencil

### DIFF
--- a/Samples/Stencil/UserControlsInStencil/Sample/App.xaml
+++ b/Samples/Stencil/UserControlsInStencil/Sample/App.xaml
@@ -6,31 +6,45 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/Syncfusion.SfDiagram.Wpf;component/Resources/BindingStyle.xaml" />
                 <ResourceDictionary Source="/Syncfusion.SfDiagram.Wpf;component/Resources/BasicShapes.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <!--Data template for button node-->
             <DataTemplate x:Key="custombuttontemplate">
                 <Border Background="Transparent" BorderBrush="Gray" BorderThickness="0.5" >
                     <Button Content="{Binding Text}"  IsHitTestVisible="{Binding IsHitTestVisible}"></Button>
                 </Border>
             </DataTemplate>
+
+            <!--Data template for combo box node-->
             <DataTemplate x:Key="customcomboboxtemplate">
-                <ComboBox x:Name="cboBox1" ItemsSource="{Binding Items}" IsHitTestVisible="{Binding IsHitTestVisible}"  SelectedIndex="0"  DisplayMemberPath="Name" MinWidth="120">
-                </ComboBox>
+                <Border Background="Transparent" BorderBrush="Gray" Width="110" Height="60" BorderThickness="0.5" >
+                    <ComboBox x:Name="cboBox1" ItemsSource="{Binding Items}" IsHitTestVisible="{Binding IsHitTestVisible}"  SelectedIndex="0"  DisplayMemberPath="Name" Width="100" Height="50">
+                    </ComboBox>
+                </Border>
             </DataTemplate>
-            <DataTemplate x:Key="customDataGridtemplate">
-                <DataGrid ItemsSource="{Binding Employees}" IsHitTestVisible="{Binding IsHitTestVisible}" />
-            </DataTemplate>
+
+            <!--Data template for text box node-->
             <DataTemplate x:Key="customTextBoxtemplate">
-                <TextBox Text="{Binding Text}" IsHitTestVisible="{Binding IsHitTestVisible}"></TextBox>
+                <Border Background="Transparent" BorderBrush="Gray" BorderThickness="0.5" >
+                    <TextBox Text="{Binding Text}" IsHitTestVisible="{Binding IsHitTestVisible}"></TextBox>
+                </Border>
             </DataTemplate>
+
+            <!--Data template for text block node-->
             <DataTemplate x:Key="customtextBlocktemplate">
-                <TextBlock Text="{Binding Text}" IsHitTestVisible="{Binding IsHitTestVisible}" Background="LightGray"></TextBlock>
+                <Border Background="Transparent" BorderBrush="Gray" BorderThickness="0.5" >
+                    <TextBlock Text="{Binding Text}" IsHitTestVisible="{Binding IsHitTestVisible}" Background="LightGray"></TextBlock>
+                </Border>
             </DataTemplate>
+
+            <!--Data template for ellipse node-->
             <DataTemplate x:Key="customEllipsetemplate">
-                <Ellipse   Stretch="Fill" Fill="Gray"></Ellipse>
+                <Border Background="Transparent" BorderBrush="Transparent" BorderThickness="0.5" >
+                    <Ellipse Stretch="Fill" Fill="Gray"></Ellipse>
+                </Border>
             </DataTemplate>
+            
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Samples/Stencil/UserControlsInStencil/Sample/MainWindow.xaml
+++ b/Samples/Stencil/UserControlsInStencil/Sample/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:stencil="clr-namespace:Syncfusion.UI.Xaml.Diagram.Stencil;assembly=Syncfusion.SfDiagram.Wpf"
         xmlns:local="clr-namespace:Xaml_Designer"
         mc:Ignorable="d"
-        Title="MainWindow" Height="350" Width="525">
+        Title="UsersControlsInStencil" Height="350" Width="525">
     <Window.Resources>
 
         <Style TargetType="Path"  x:Key="shapestyle">
@@ -17,15 +17,6 @@
             <Setter Property="StrokeThickness" Value="2"/>
         </Style>
 
-        <Style TargetType="syncfusion:Node" BasedOn="{StaticResource NodeBindingStyle}">
-            <Setter Property="Background" Value="Transparent"/>
-        </Style>
-        <Style TargetType="syncfusion:Connector" BasedOn="{StaticResource ConnectorBindingStyle}">
-
-        </Style>
-        <Style TargetType="syncfusion:AnnotationEditor" BasedOn="{StaticResource AnnotationEditorBindingStyle}">
-
-        </Style>
         <Style TargetType="stencil:Symbol">
             <Setter Property="Width" Value="50" />
             <Setter Property="Height" Value="50" />
@@ -96,12 +87,22 @@
                 </stencil:Stencil.SelectedFilter>
                 <stencil:Stencil.SymbolSource>
                     <local:SymbolCollection>
-                        <local:CustomNode ContenTempName="custombuttontemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource custombuttontemplate}">
+                        <!--Button node-->
+                        <local:CustomNode ContentTemplatKey="custombuttontemplate"  UnitHeight="50" 
+                                          Key="Controls" UnitWidth="70"
+                                          ContentTemplate="{StaticResource custombuttontemplate}">
                             <local:CustomNode.Content>
-                                <local:CustomButton Text="Button" ></local:CustomButton>
+                                <local:NodeContent Text="Button" ></local:NodeContent>
                             </local:CustomNode.Content>
+                            <local:CustomNode.CustomContent>
+                                <local:NodeContent Text="Button" ></local:NodeContent>
+                            </local:CustomNode.CustomContent>
                         </local:CustomNode>
-                        <local:CustomNode ContenTempName="customcomboboxtemplate" UnitHeight="50"   Key="Controls" UnitWidth="100" ContentTemplate="{StaticResource customcomboboxtemplate}">
+
+                        <!--Combobox node-->
+                        <local:CustomNode ContentTemplatKey="customcomboboxtemplate" UnitHeight="60" 
+                                      Key="Controls" UnitWidth="110"
+                                      ContentTemplate="{StaticResource customcomboboxtemplate}">
                             <local:CustomNode.Content>
                                 <local:CustomComboBox>
                                     <local:CustomComboBox.Items>
@@ -109,37 +110,43 @@
                                             <local:Person Name="combobox1"></local:Person>
                                             <local:Person Name="combobox2"></local:Person>
                                         </local:ComboboxItems>
-
                                     </local:CustomComboBox.Items>
                                 </local:CustomComboBox>
                             </local:CustomNode.Content>
+                            <local:CustomNode.CustomComboBoxContent>
+                                <local:CustomComboBox>
+                                    <local:CustomComboBox.Items>
+                                        <local:ComboboxItems>
+                                            <local:Person Name="combobox1"></local:Person>
+                                            <local:Person Name="combobox2"></local:Person>
+                                        </local:ComboboxItems>
+                                    </local:CustomComboBox.Items>
+                                </local:CustomComboBox>
+                            </local:CustomNode.CustomComboBoxContent>
                         </local:CustomNode>
-                        <local:CustomNode ContenTempName="customDataGridtemplate"  UnitHeight="70"   Key="Controls" UnitWidth="200" ContentTemplate="{StaticResource customDataGridtemplate}">
+
+                        <!--TextBox node-->
+                        <local:CustomNode ContentTemplatKey="customTextBoxtemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource customTextBoxtemplate}">
                             <local:CustomNode.Content>
-                                <local:CustomDataGrid >
-                                    <local:CustomDataGrid.Employees>
-                                        <local:EmployeeCollection>
-                                            <local:Employee Id="1" Name="Emp1" PhoneNumber="123456"></local:Employee>
-                                            <local:Employee Id="2" Name="Emp2" PhoneNumber="123456"></local:Employee>
-                                        </local:EmployeeCollection>
-                                    </local:CustomDataGrid.Employees>
-                                </local:CustomDataGrid>
+                                <local:NodeContent Text="TextBox"></local:NodeContent>
                             </local:CustomNode.Content>
+                            <local:CustomNode.CustomContent>
+                                <local:NodeContent Text="TextBox"></local:NodeContent>
+                            </local:CustomNode.CustomContent>
                         </local:CustomNode>
-                        <local:CustomNode ContenTempName="customTextBoxtemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource customTextBoxtemplate}">
+
+                        <!--TextBlock node-->
+                        <local:CustomNode ContentTemplatKey="customtextBlocktemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource customtextBlocktemplate}">
                             <local:CustomNode.Content>
-                                <local:CustomTextBox Text="TextBox"></local:CustomTextBox>
+                                <local:NodeContent Text="textBlock"></local:NodeContent>
                             </local:CustomNode.Content>
+                            <local:CustomNode.CustomContent>
+                                <local:NodeContent Text="textBlock"></local:NodeContent>
+                            </local:CustomNode.CustomContent>
                         </local:CustomNode>
-                        <local:CustomNode ContenTempName="customtextBlocktemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource customtextBlocktemplate}">
-                            <local:CustomNode.Content>
-                                <local:CustomTextBlock Text="textBlock"></local:CustomTextBlock>
-                            </local:CustomNode.Content>
-                        </local:CustomNode>
-                        <local:CustomNode ContenTempName="customEllipsetemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource customEllipsetemplate}">
-                            <local:CustomNode.Content>
-                                <local:CustomEllipse Text="Ellipse"></local:CustomEllipse>
-                            </local:CustomNode.Content>
+
+                        <!--Ellipse node-->
+                        <local:CustomNode ContentTemplatKey="customEllipsetemplate"  UnitHeight="50"   Key="Controls" UnitWidth="70" ContentTemplate="{StaticResource customEllipsetemplate}">
                         </local:CustomNode>
                     </local:SymbolCollection>
                 </stencil:Stencil.SymbolSource>
@@ -156,7 +163,6 @@
             <!--Initializes Connector-->
             <syncfusion:SfDiagram.Connectors>
                 <syncfusion:ConnectorCollection>
-
                 </syncfusion:ConnectorCollection>
             </syncfusion:SfDiagram.Connectors>
             <syncfusion:SfDiagram.Groups>

--- a/Samples/Stencil/UserControlsInStencil/Sample/MainWindow.xaml.cs
+++ b/Samples/Stencil/UserControlsInStencil/Sample/MainWindow.xaml.cs
@@ -29,27 +29,24 @@ namespace Xaml_Designer
         public MainWindow()
         {
             InitializeComponent();
-
             diagram.PageSettings.PageBorderBrush = new SolidColorBrush(Colors.Transparent);
+            //Adding known types to the diagram
             diagram.KnownTypes = GetKnownTypes;
-
         }
 
         private bool SymbolFilter(SymbolFilterProvider sender, object symbol)
         {
             return true;
         }
+
+        //Setting known class to the diagram to serialize
         private IEnumerable<Type> GetKnownTypes()
         {
             List<Type> known = new List<Type>()
             {
-                typeof(CustomButton),
+                typeof(NodeContent),
                  typeof(CustomComboBox),
-                 typeof(CustomDataGrid),
-                 typeof(CustomTextBox),
-                 typeof(CustomTextBlock),
-                 typeof(CustomEllipse)
-
+                 typeof(Person),
             };
             foreach (var item in known)
             {
@@ -57,23 +54,33 @@ namespace Xaml_Designer
             }
         }
     }
-    public class CustomButton:NodeViewModel
+
+    /// <summary>
+    /// Reprsents a class that stores text value to the node content.
+    /// </summary>
+    [DataContract]
+    public class NodeContent
     {
-        private bool _IsHitTestVisible=false;
+        private bool _IsHitTestVisible = false;
         [DataMember]
         public bool IsHitTestVisible
         {
             get { return _IsHitTestVisible; }
             set
             {
-                if(value!=_IsHitTestVisible)
+                if (value != _IsHitTestVisible)
                 {
                     _IsHitTestVisible = value;
-                   OnPropertyChanged("IsHitTestVisible");
+                    OnPropertyChanged("IsHitTestVisible");
                 }
             }
         }
+
         private string _text;
+
+        /// <summary>
+        /// Gets or sets the text values to the node's content.
+        /// </summary>
         [DataMember]
         public string Text
         {
@@ -88,23 +95,43 @@ namespace Xaml_Designer
             }
         }
 
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string name)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(name));
+            }
+        }
     }
-    public class CustomComboBox:NodeViewModel
+
+    /// <summary>
+    /// Represents a class that stores combobox values to the node's content property.
+    /// </summary>
+    [DataContract]
+    public class CustomComboBox
     {
-        private ObservableCollection<Person> _text;
+        private ObservableCollection<Person> _items;
+
+        /// <summary>
+        /// Gets or sets items that needs to be display in the combobox.
+        /// </summary>
         [DataMember]
         public ObservableCollection<Person> Items
         {
-            get { return _text; }
+            get { return _items; }
             set
             {
-                if (value != _text)
+                if (value != _items)
                 {
-                    _text = value;
+                    _items = value;
                     OnPropertyChanged("Items");
                 }
             }
         }
+
         private bool _IsHitTestVisible = false;
         [DataMember]
         public bool IsHitTestVisible
@@ -119,149 +146,55 @@ namespace Xaml_Designer
                 }
             }
         }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string name)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(name));
+            }
+        }
     }
+
+    /// <summary>
+    /// Represents the class that stores name values to the combobox items
+    /// </summary>
+    [DataContract]
     public class Person
     {
+        [DataMember]
         public string  Name { get; set; }
     }
-    public class CustomDataGrid:NodeViewModel
-    {
-        private ObservableCollection<Employee> _text;
-        [DataMember]
-        public ObservableCollection<Employee> Employees
-        {
-            get { return _text; }
-            set
-            {
-                if (value != _text)
-                {
-                    _text = value;
-                    OnPropertyChanged("Employees");
-                }
-            }
-        }
-        private bool _IsHitTestVisible = false;
-        [DataMember]
-        public bool IsHitTestVisible
-        {
-            get { return _IsHitTestVisible; }
-            set
-            {
-                if (value != _IsHitTestVisible)
-                {
-                    _IsHitTestVisible = value;
-                    OnPropertyChanged("IsHitTestVisible");
-                }
-            }
-        }
-    }
-    public class Employee
-    {
-        public string Name { get; set; }
-        public int Id { get; set; }
-        public string PhoneNumber { get; set; }
-    }
-    public class EmployeeCollection : ObservableCollection<Employee>
-    {
 
-    }
-    public class CustomEllipse:NodeViewModel
-    {
-        private string _text;
-        [DataMember]
-        public string Text
-        {
-            get { return _text; }
-            set
-            {
-                if (value != _text)
-                {
-                    _text = value;
-                    OnPropertyChanged("Text");
-                }
-            }
-        }
-
-    }
-    public class CustomTextBlock:NodeViewModel
-    {
-        private string _text;
-        [DataMember]
-        public string Text
-        {
-            get { return _text; }
-            set
-            {
-                if (value != _text)
-                {
-                    _text = value;
-                    OnPropertyChanged("Text");
-                }
-            }
-        }
-        private bool _IsHitTestVisible = false;
-        [DataMember]
-        public bool IsHitTestVisible
-        {
-            get { return _IsHitTestVisible; }
-            set
-            {
-                if (value != _IsHitTestVisible)
-                {
-                    _IsHitTestVisible = value;
-                    OnPropertyChanged("IsHitTestVisible");
-                }
-            }
-        }
-    }
-    public class CustomTextBox:NodeViewModel
-    {
-        private string _text;
-        [DataMember]
-        public string Text
-        {
-            get { return _text; }
-            set
-            {
-                if (value != _text)
-                {
-                    _text = value;
-                    OnPropertyChanged("Text");
-                }
-            }
-        }
-        private bool _IsHitTestVisible = false;
-        [DataMember]
-        public bool IsHitTestVisible
-        {
-            get { return _IsHitTestVisible; }
-            set
-            {
-                if (value != _IsHitTestVisible)
-                {
-                    _IsHitTestVisible = value;
-                    OnPropertyChanged("IsHitTestVisible");
-                }
-            }
-        }
-    }
     public class annaotioncollection : ObservableCollection<IAnnotation>
     {
 
     }
+
     public class SymbolCollection : ObservableCollection<object>
     {
 
     }
+
     public class ComboboxItems : ObservableCollection<Person>
     {
 
     }
+
+    /// <summary>
+    /// Represents a class that derived from NodeViewModel and it stores custom content template and custom content values and they used to serialize the node's original Content and ContentTemplate property values.
+    /// </summary>
     public class CustomNode:NodeViewModel
     {
         private string _ContenttempName = string.Empty;
+        /// <summary>
+        /// Gets or sets the key value to access the data template of node from resource file.
+        /// </summary>
         [DataMember]
-        public string ContenTempName
+        public string ContentTemplatKey
         {
             get { return _ContenttempName; }
             set
@@ -270,24 +203,50 @@ namespace Xaml_Designer
                 {
                     _ContenttempName = value;
                     this.ContentTemplate = App.Current.Resources[_ContenttempName] as DataTemplate;
-                    OnPropertyChanged("ContenTempName");
-                }
-            }
-        }
-        
-        [DataMember]
-        public object DummyContent
-        {
-            get { return Content; }
-            set
-            {
-                if (value != Content)
-                {
-                    Content = value;
-                    OnPropertyChanged("Text");
+                    OnPropertyChanged("ContentTemplatKey");
                 }
             }
         }
 
+        private NodeContent _mcustomcontent;
+        /// <summary>
+        /// Gets or sets the content of the node.
+        /// </summary>
+        [DataMember]
+        public NodeContent CustomContent
+        {
+            get { return _mcustomcontent; }
+            set
+            {
+                if (value != _mcustomcontent)
+                {
+                    _mcustomcontent = value;
+                    this.Content = CustomContent;
+                    OnPropertyChanged("CustomContent");
+                }
+            }
+        }
+
+        private CustomComboBox _mcustomComboBoxContent;
+        /// <summary>
+        /// Gets or sets the custom content to the combobox node.
+        /// </summary>
+        [DataMember]
+        public CustomComboBox CustomComboBoxContent
+        {
+            get 
+            { 
+                return _mcustomComboBoxContent;
+            }
+            set
+            {
+                if (value != _mcustomComboBoxContent)
+                {
+                    _mcustomComboBoxContent = value;
+                    this.Content = CustomComboBoxContent;
+                    OnPropertyChanged("CustomComboBoxContent");
+                }
+            }
+        }
     }
 }

--- a/Samples/Stencil/UserControlsInStencil/Sample/packages.config
+++ b/Samples/Stencil/UserControlsInStencil/Sample/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Licensing" version="21.1.35" targetFramework="net46" />
-  <package id="Syncfusion.PropertyGrid.WPF" version="21.1.35" targetFramework="net46" />
-  <package id="Syncfusion.SfDiagram.WPF" version="21.1.35" targetFramework="net46" />
-  <package id="Syncfusion.SfInput.WPF" version="21.1.35" targetFramework="net46" />
-  <package id="Syncfusion.Shared.WPF" version="21.1.35" targetFramework="net46" />
-  <package id="Syncfusion.Tools.WPF" version="21.1.35" targetFramework="net46" />
+  <package id="Syncfusion.Licensing" version="23.1.42" targetFramework="net46" />
+  <package id="Syncfusion.PropertyGrid.WPF" version="23.1.42" targetFramework="net46" />
+  <package id="Syncfusion.SfDiagram.WPF" version="23.1.42" targetFramework="net46" />
+  <package id="Syncfusion.SfInput.WPF" version="23.1.42" targetFramework="net46" />
+  <package id="Syncfusion.Shared.WPF" version="23.1.42" targetFramework="net46" />
+  <package id="Syncfusion.Tools.WPF" version="23.1.42" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Sample in the WPF-Diagram-Examples\Samples\Stencil\UserControlsInStencil location is not working. Symbols are not dragging from the stencil to diagram. As it is reported by the customer in this ticket 515178.