### PR TITLE
WPF-1010536-Need to remove ConnectorLength property from Forced Directed Tree sample

### DIFF
--- a/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeCodeBehind/MainWindow.xaml
+++ b/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeCodeBehind/MainWindow.xaml
@@ -104,32 +104,24 @@
                     <RowDefinition Height="45" ></RowDefinition>
                     <RowDefinition Height="45"></RowDefinition>
                     <RowDefinition Height="45" ></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
-                    <RowDefinition Height="45" ></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
-                    <RowDefinition Height="45" ></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
+                    
+                    
 
                 </Grid.RowDefinitions>
 
                 <TextBlock Margin="10,10,0,0" Grid.Row="0" Grid.ColumnSpan="2" Text="Properties" Foreground="#0075C0" 
                      FontWeight="Bold" FontSize="13pt"/>
 
-                <TextBlock Margin="10,5,0,0" Grid.Row="1" Grid.Column="0" Text="ConnectorLength"  Height="25" VerticalAlignment="Center"/>
-                <Syncfusion:UpDown MinValue="50" Margin="5,5,0,0" Grid.Row="1" Grid.Column="1" Value="110" ValueChanged="UpDown_ValueChanged" Step="5" MaxValue="200"
-                                           />
-
-                <TextBlock Margin="10,5,0,0" Grid.Row="2" Grid.Column="0" Text="Max Iteration" VerticalAlignment="Center"  Height="25"/>
-                <Syncfusion:UpDown MinValue="300" Margin="5,5,0,0" Grid.Row="2" Grid.Column="1" Value="2500" ValueChanged="UpDown_ValueChanged_1" Step="50"
+                <TextBlock Margin="10,5,0,0" Grid.Row="1" Grid.Column="0" Text="Max Iteration" VerticalAlignment="Center"  Height="25"/>
+                <Syncfusion:UpDown MinValue="300" Margin="5,5,0,0" Grid.Row="1" Grid.Column="1" Value="2500" ValueChanged="UpDown_ValueChanged_1" Step="50"
                                          />
 
-                <TextBlock Margin="10,5,0,0" Grid.Row="3" Grid.Column="0" Text="Repulsion Strength"  Height="25" VerticalAlignment="Center"/>
-                <Syncfusion:UpDown MinValue="10000" Margin="5,5,0,0" Grid.Row="3" Grid.Column="1" Value="25000" ValueChanged="UpDown_ValueChanged_2" Step="200" MaxValue="30000"
+                <TextBlock Margin="10,5,0,0" Grid.Row="2" Grid.Column="0" Text="Repulsion Strength"  Height="25" VerticalAlignment="Center"/>
+                <Syncfusion:UpDown MinValue="10000" Margin="5,5,0,0" Grid.Row="2" Grid.Column="1" Value="25000" ValueChanged="UpDown_ValueChanged_2" Step="200" MaxValue="30000"
                           />
 
-                <TextBlock Margin="10,0,0,0" Grid.Row="4" Grid.Column="0" Text="Attraction strength"  Height="26" VerticalAlignment="Center"/>
-                <Syncfusion:UpDown MinValue="0.1" MaxValue="1" Margin="5,5,0,0" Grid.Row="4" Value="0.6" ValueChanged="UpDown_ValueChanged_3" Grid.Column="1" Step="0.1"
+                <TextBlock Margin="10,0,0,0" Grid.Row="3" Grid.Column="0" Text="Attraction strength"  Height="26" VerticalAlignment="Center"/>
+                <Syncfusion:UpDown MinValue="0.1" MaxValue="1" Margin="5,5,0,0" Grid.Row="3" Value="0.6" ValueChanged="UpDown_ValueChanged_3" Grid.Column="1" Step="0.1"
                           />
 
 

--- a/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeCodeBehind/MainWindow.xaml.cs
+++ b/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeCodeBehind/MainWindow.xaml.cs
@@ -49,7 +49,6 @@ namespace ForceDirectedTreeCodeBehind
             {
                 Layout = new ForceDirectedTree()
                 {
-                    ConnectorLength = 110,
                     AttractionStrength = 0.6,
                     RepulsionStrength = 25000,
                     MaximumIteration = 2500,
@@ -195,13 +194,6 @@ namespace ForceDirectedTreeCodeBehind
                 // e.g. TargetDecorator = new DecoratorViewModel { Shape = DecoratorShapes.Arrow }
             };
         }
-
-        private void UpDown_ValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if(Diagram.LayoutManager != null)
-            (Diagram.LayoutManager.Layout as ForceDirectedTree).ConnectorLength = (double)e.NewValue;
-        }
-
         private void UpDown_ValueChanged_1(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (Diagram.LayoutManager != null)

--- a/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeDataSource/MainWindow.xaml
+++ b/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeDataSource/MainWindow.xaml
@@ -43,7 +43,7 @@
                 <Setter Property="UnitWidth" Value="130"/>
 
             </Style>
-         
+
             <!--Style for Connector-->
             <Style TargetType="Syncfusion:Connector">
                 <Setter Property="ConnectorGeometryStyle">
@@ -102,33 +102,22 @@
                     <RowDefinition Height="35" ></RowDefinition>
                     <RowDefinition Height="35"></RowDefinition>
                     <RowDefinition Height="35" ></RowDefinition>
-                    <RowDefinition Height="35"></RowDefinition>
-                    <RowDefinition Height="35" ></RowDefinition>
-                    <RowDefinition Height="75"></RowDefinition>
-                    <RowDefinition Height="35"></RowDefinition>
-                    <RowDefinition Height="35"></RowDefinition>
-                    <RowDefinition Height="35"></RowDefinition>
-                    
 
                 </Grid.RowDefinitions>
 
                 <TextBlock Margin="10,10,0,0" Grid.Row="0" Grid.ColumnSpan="2" Text="Properties" Foreground="#0075C0" 
                      FontWeight="Bold" FontSize="13pt"/>
 
-                <TextBlock Margin="10,5,0,0" Grid.Row="1" Grid.Column="0" Text="ConnectorLength"  Height="25" VerticalAlignment="Center"/>
-                <Syncfusion:UpDown x:Name="connectorlength" MinValue="100" Margin="5,5,0,0" Grid.Row="1" Grid.Column="1" Step="5" MaxValue="170"
-                                          Value="{Binding ConnectorLength, Mode=TwoWay}" />
-
-                <TextBlock Margin="10,5,0,0" Grid.Row="2" Grid.Column="0" Text="Max Iteration" VerticalAlignment="Center"  Height="25"/>
-                <Syncfusion:UpDown x:Name="maxiteration" MinValue="300" Margin="5,5,0,0" Grid.Row="2" Grid.Column="1" Step="50"
+                <TextBlock Margin="10,5,0,0" Grid.Row="1" Grid.Column="0" Text="Max Iteration" VerticalAlignment="Center"  Height="25"/>
+                <Syncfusion:UpDown x:Name="maxiteration" MinValue="300" Margin="5,5,0,0" Grid.Row="1" Grid.Column="1" Step="50"
                                           Value="{Binding MaximumIteration, Mode=TwoWay}"/>
 
-                <TextBlock Margin="10,5,0,0" Grid.Row="3" Grid.Column="0" Text="Repulsion Strength"  Height="25" VerticalAlignment="Center"/>
-                <Syncfusion:UpDown x:Name="repulsionstrength" MinValue="25000" Margin="5,5,0,0" Grid.Row="3" Grid.Column="1" Step="250" MaxValue="30000"
+                <TextBlock Margin="10,5,0,0" Grid.Row="2" Grid.Column="0" Text="Repulsion Strength"  Height="25" VerticalAlignment="Center"/>
+                <Syncfusion:UpDown x:Name="repulsionstrength" MinValue="25000" Margin="5,5,0,0" Grid.Row="2" Grid.Column="1" Step="250" MaxValue="30000"
                           Value="{Binding RepulsionStrength, Mode=TwoWay}" />
 
-                <TextBlock Margin="10,0,0,0" Grid.Row="4" Grid.Column="0" Text="Attraction strength"  Height="26" VerticalAlignment="Center"/>
-                <Syncfusion:UpDown x:Name="attractionstrength" MinValue="0.1" MaxValue="1" Margin="5,5,0,0" Grid.Row="4" Grid.Column="1" Step="0.1"
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="Attraction strength"  Height="26" VerticalAlignment="Center" HorizontalAlignment="Right" Width="120"/>
+                <Syncfusion:UpDown x:Name="attractionstrength" MinValue="0.1" MaxValue="1" Margin="5,5,0,0" Grid.Row="3" Grid.Column="1" Step="0.1"
                           Value="{Binding AttractionStrength, Mode=TwoWay}" />
 
             </Grid>

--- a/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeDataSource/ViewModel/ForceDirectedViewModel.cs
+++ b/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeDataSource/ViewModel/ForceDirectedViewModel.cs
@@ -138,7 +138,6 @@ namespace Force_directed_tree.ViewModel
             {
                 Layout = new ForceDirectedTree()
                 {
-                    ConnectorLength = 110,
                     AttractionStrength = 0.6,
                     RepulsionStrength = 25000,
                     MaximumIteration = 1000,

--- a/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeView/MainWindow.xaml
+++ b/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeView/MainWindow.xaml
@@ -472,7 +472,7 @@
             <syncfusion:SfDiagram.LayoutManager>
                 <syncfusion:LayoutManager>
                     <syncfusion:LayoutManager.Layout>
-                        <syncfusion:ForceDirectedTree ConnectorLength="110"
+                        <syncfusion:ForceDirectedTree
                                           AttractionStrength="0.6"
                                           RepulsionStrength="25000"
                                           MaximumIteration="2500" />
@@ -493,32 +493,23 @@
                     <RowDefinition Height="45" ></RowDefinition>
                     <RowDefinition Height="45"></RowDefinition>
                     <RowDefinition Height="45" ></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
-                    <RowDefinition Height="45" ></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
-                    <RowDefinition Height="45" ></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
-                    <RowDefinition Height="45"></RowDefinition>
+                    
 
                 </Grid.RowDefinitions>
 
                 <TextBlock Margin="10,10,0,0" Grid.Row="0" Grid.ColumnSpan="2" Text="Properties" Foreground="#0075C0" 
                      FontWeight="Bold" FontSize="13pt"/>
 
-                <TextBlock Margin="10,5,0,0" Grid.Row="1" Grid.Column="0" Text="ConnectorLength"  Height="25" VerticalAlignment="Center"/>
-                <syncfusion:UpDown MinValue="50" Margin="5,5,0,0" Grid.Row="1" Grid.Column="1" Value="150" ValueChanged="UpDown_ValueChanged" Step="5" MaxValue="200"
-                                           />
-
-                <TextBlock Margin="10,5,0,0" Grid.Row="2" Grid.Column="0" Text="Max Iteration" VerticalAlignment="Center"  Height="25"/>
-                <syncfusion:UpDown MinValue="300" Margin="5,5,0,0" Grid.Row="2" Grid.Column="1" Value="2500" ValueChanged="UpDown_ValueChanged_1" Step="50"
+                <TextBlock Margin="10,5,0,0" Grid.Row="1" Grid.Column="0" Text="Max Iteration" VerticalAlignment="Center"  Height="25"/>
+                <syncfusion:UpDown MinValue="300" Margin="5,5,0,0" Grid.Row="1" Grid.Column="1" Value="2500" ValueChanged="UpDown_ValueChanged_1" Step="50"
                                          />
 
-                <TextBlock Margin="10,5,0,0" Grid.Row="3" Grid.Column="0" Text="Repulsion Strength"  Height="25" VerticalAlignment="Center"/>
-                <syncfusion:UpDown MinValue="10000" Margin="5,5,0,0" Grid.Row="3" Grid.Column="1" Value="25000" ValueChanged="UpDown_ValueChanged_2" Step="200" MaxValue="30000"
+                <TextBlock Margin="10,5,0,0" Grid.Row="2" Grid.Column="0" Text="Repulsion Strength"  Height="25" VerticalAlignment="Center"/>
+                <syncfusion:UpDown MinValue="10000" Margin="5,5,0,0" Grid.Row="2" Grid.Column="1" Value="25000" ValueChanged="UpDown_ValueChanged_2" Step="200" MaxValue="30000"
                           />
 
-                <TextBlock Margin="10,0,0,0" Grid.Row="4" Grid.Column="0" Text="Attraction strength"  Height="26" VerticalAlignment="Center"/>
-                <syncfusion:UpDown MinValue="0.1" MaxValue="1" Margin="5,5,0,0" Grid.Row="4" Value="0.6" ValueChanged="UpDown_ValueChanged_3" Grid.Column="1" Step="0.1"
+                <TextBlock Margin="10,0,0,0" Grid.Row="3" Grid.Column="0" Text="Attraction strength"  Height="26" VerticalAlignment="Center"/>
+                <syncfusion:UpDown MinValue="0.1" MaxValue="1" Margin="5,5,0,0" Grid.Row="3" Value="0.6" ValueChanged="UpDown_ValueChanged_3" Grid.Column="1" Step="0.1"
                           />
 
 

--- a/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeView/MainWindow.xaml.cs
+++ b/Samples/Automatic Layout/Force Directed Tree layout/ForceDirectedTreeView/MainWindow.xaml.cs
@@ -45,17 +45,6 @@ namespace ForceDirectedTreeView
             (Diagram.Info as IGraphInfo).Commands.FitToPage.Execute(null);
             temp = true;
         }
-
-        private void UpDown_ValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (temp)
-            {
-                if ((Diagram.LayoutManager.Layout as ForceDirectedTree).ConnectorLength != (double)e.NewValue)
-                    (Diagram.LayoutManager.Layout as ForceDirectedTree).ConnectorLength = (double)e.NewValue;
-                temp = true;
-            }
-        }
-
         private void UpDown_ValueChanged_1(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (temp)


### PR DESCRIPTION
### Description ###

Need to remove ConnectorLength property from Forced Directed Tree sample

### Output screenshots ###

**Force Directed Tree using View :**

<img width="959" height="563" alt="image" src="https://github.com/user-attachments/assets/0a28fa6e-9435-4129-a117-df0bf8ec58da" />

**Force Directed Tree using C#:** 

<img width="959" height="564" alt="image" src="https://github.com/user-attachments/assets/8a53e1af-e4b7-4049-841b-d8bf37e885ef" />

**Force Directed Tree using Data Source:**

<img width="959" height="565" alt="image" src="https://github.com/user-attachments/assets/3e79e448-bd14-4a61-a9dc-bbb1cba5c52d" />


### Does it have memory leak? [how to clear memory leak](https://syncfusion.atlassian.net/wiki/spaces/XAML/pages/1932001958/Product+Demo#Dispose)

No

### MR CheckList ###

* [ ] Demos are added in SB as per [guideline](https://syncfusion.atlassian.net/wiki/spaces/XAML/pages/1932001958/Product+Demo)
* [ ] Ensured files and resources are correctly added to the Assets folder in SB as per [guideline](https://syncfusion.atlassian.net/wiki/spaces/XAML/pages/1796309199/How+to+use+assets+resources+in+samples)
* [ ] Ensure .png and .jpeg images are not added and used only paths.
* [ ] Descriptions of the control and sample are reviewed by content team.
* [ ] Converter and utils are not added in Sample and added only in Common project. 
* [ ] Options are used as per [guideline](https://syncfusion.atlassian.net/wiki/spaces/XAML/pages/1932001958/Product+Demo#Configure-Properties/Option-view)
* [ ] Warning and binding errors ensured?
* [ ] `.csproj` files changes included in `_lib` project also.
* [ ] Tested autogenerated .NetCore and .Net projects?.